### PR TITLE
Include user-agent in MIIC excel sheet fetch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,9 @@ task :load_miic_mapping do
   end
   miic_map_path = "./miic-mapping.csv"
   url = "https://www.health.state.mn.us/people/immunize/miic/data/vaxcodes.xlsx"
-  miic_xls = HTTParty.get(url)
+  miic_xls = HTTParty.get(url, headers: {
+    "User-Agent" => "Docket/1.0", # MIIC gives back a 403 if a user agent is not populated
+  })
   miic_xls_data = StringIO.new miic_xls.body
   xls_file = Roo::Excelx.new(miic_xls_data)
   File.write(miic_map_path, xls_file.to_csv)


### PR DESCRIPTION
Hrm. The GH workflow is failing (eg https://github.com/hellodocket/vaccine-code-mappings/actions/runs/11368439757) because we started getting 403s when fetching the excel sheet. This fixes it with a custom user agent.