### PR TITLE
Modify MIIC user agent to look more like a browser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :load_miic_mapping do
   miic_map_path = "./miic-mapping.csv"
   url = "https://www.health.state.mn.us/people/immunize/miic/data/vaxcodes.xlsx"
   miic_xls = HTTParty.get(url, headers: {
-    "User-Agent" => "Docket/1.0", # MIIC gives back a 403 if a user agent is not populated
+    "User-Agent" => "Mozilla/5.0 (X11; Linux x86_64) Docket/1.0", # MIIC gives back a 403 if a user agent is not populated
   })
   miic_xls_data = StringIO.new miic_xls.body
   xls_file = Roo::Excelx.new(miic_xls_data)


### PR DESCRIPTION
1. I used HTTParty.get with no user agent got 403.
1. I used HTTParty.get with an actual user agent copied from my browser and got a 200.
1. I swapped the user agent to "Docket/1.0" and got a 200.
1. I push changes.
1. Workflow fails.
1. I come back 30 minutes later.
1. I again HTTParty.get with "Docket/1.0". Now I get 403. Sad.
1. I swap to a more real looking user agent. I get 200.
1. I swap back to "Docket/1.0". I get 200.
1. Anger.

Result: We use more real looking user agent.