### PR TITLE
Remove MN data file from GH workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Run CDC Rake task
         run: bundle exec rake load_cdc_mapping
 
-      - name: Run MIIC Rake task
-        run: bundle exec rake load_miic_mapping
-
       - name: Set Release Version
         id: releaseVersion
         run: echo "RELEASE_NAME=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,10 @@ end
 
 desc "Download and convert the Excel file for MIIC"
 task :load_miic_mapping do
+  # This was removed from the GitHub workflow on 2025-05-07.
+  # MIIC seems to have removed the data file, so this will fail indefinitely.
+  # There is an email out to Aaron, Miriam, and Sydney from MN to ask what happened.
+
   def trade_name_overrides
     # These only really need to be defined for COVID-19 for now since they're rapidly changing.
     # The data comes from https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html


### PR DESCRIPTION
https://www.health.state.mn.us/people/immunize/miic/data/codes.html no longer lists the vaxcodes.xlsx file. I think perhaps they've removed their custom vaccine naming.

I have an email out to the MN team asking what happened.