### PR TITLE
Add custom Utah 943 cvx code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can run the task to generate the actual mapping with the following
 
 ```
 bundle install
-bundle exec rake load_mapping
+bundle exec rake load_cdc_mapping
 ```
 
 ## Creating a Release

--- a/vaccine-code-mapping.json
+++ b/vaccine-code-mapping.json
@@ -7092,6 +7092,44 @@
         }
       ]
     },
+    "943": {
+      "cvx_code": "943",
+      "name": "Hep B, adult",
+      "description": "Hep B, adult",
+      "status": "Active",
+      "cpt_codes": [
+        {
+          "cpt_code": "90743",
+          "cpt_desc": "Hepatitis B vaccine (HepB), adolescent, 2 dose schedule, for intramuscular use"
+        },
+        {
+          "cpt_code": "90746",
+          "cpt_desc": "Hepatitis B vaccine (HepB), adult dosage, 3 dose schedule, for intramuscular use"
+        }
+      ],
+      "groups": {
+        "45": {
+          "name": "HepB",
+          "active": true
+        }
+      },
+      "manufacturers": [
+        {
+          "trade_name": "ENGERIX-B-ADULT",
+          "mvx_code": "SKB",
+          "manufacturer": "GlaxoSmithKline",
+          "last_updated": "2010-05-28",
+          "product_name_status": "Active"
+        },
+        {
+          "trade_name": "RECOMBIVAX-ADULT",
+          "mvx_code": "MSD",
+          "manufacturer": "Merck and Co., Inc.",
+          "last_updated": "2010-05-28",
+          "product_name_status": "Active"
+        }
+      ]
+    },
     "95": {
       "cvx_code": "95",
       "name": "TST-OT tine test",


### PR DESCRIPTION
So I guess Utah uses the custom 943 code when it thinks that administrations of CVX code 43 have been given such that they might count for the 2-dose HepB series.

We currently:

- **Consumer App**: Do not show these shots since we silenty skip over them.
- **Docket for Schools**: Bomb out during parsing since we use ICE and it throws if an administration is missing a CVX code.

We want to fix both of those. Rather than updating the parsing logic in nestjs-common to remap 943 to 43 _everywhere_ we parse CVX codes, I am opting to implement the fix in two steps:

1. Introduce a custom CVX code in this package so that 943 will look like a proper CVX code.
1. In `nestjs-common` we _will_ still need to implement a patch in the ICE client to map `943` to `43` since ICE won't recognize the code.

The interesting thing is that, even with this fix in place, the _forecasts_ for HepB will still be borked in the consumer app. That's because USIIS doesn't forecast correctly. For example, a patient received 943 > 08 > 08 (three doses of Hep B) such that ICE marked them complete. USIIS however, treats the 943 and 08 as being part of two different HepB series and forecasts each separately:

```
OBX|79|CE|30956-7^vaccine type^LN|18|43^HEP-B 2 DOSE^CVX||||||F
OBX|80|CE|59779-9^Immunization Schedule used^LN|18|VXC16^ACIP^CDCPHINVS||||||F|||
OBX|81|DT|30981-5^Earliest date to give^LN|18|20041130||||||F|||
OBX|82|DT|30980-7^Date vaccination due^LN|18|20041130||||||F|||
OBX|83|DT|59777-3^Latest date next dose should be given^LN|18|21090205||||||F|||
OBX|84|DT|59778-1^Date dose is overdue^LN|18|20050328||||||F|||
OBX|85|CE|30956-7^vaccine type^LN|19|45^HEP-B^CVX||||||F
OBX|86|CE|59779-9^Immunization Schedule used^LN|19|VXC16^ACIP^CDCPHINVS||||||F|||
OBX|87|DT|30981-5^Earliest date to give^LN|19|20050328||||||F|||
OBX|88|DT|30980-7^Date vaccination due^LN|19|20050328||||||F|||
OBX|89|DT|59777-3^Latest date next dose should be given^LN|19|21090205||||||F|||
OBX|90|DT|59778-1^Date dose is overdue^LN|19|20050328||||||F|||
```

There's not much we can do about that... At least in DFS we're replacing the forecast with ICE.