### PR TITLE
Pin GH action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       new_commit: ${{ steps.commitChanges.outputs.NEW_COMMIT }}
       release_name: ${{ steps.releaseVersion.outputs.RELEASE_NAME }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           bundler-cache: true
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Release
         if: ${{ steps.commitChanges.outputs.NEW_COMMIT == 1 }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: |
             vaccine-code-mapping.json,


### PR DESCRIPTION
Following up on
https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions using https://github.com/mheap/pin-github-action